### PR TITLE
Fix double-open of JSON file handles

### DIFF
--- a/common/waifu2x.cpp
+++ b/common/waifu2x.cpp
@@ -783,7 +783,7 @@ Waifu2x::eWaifu2xError Waifu2x::LoadParameterFromJson(boost::shared_ptr<caffe::N
 
 	try
 	{
-		boost::iostreams::stream<boost::iostreams::file_descriptor_source> is(param_path, std::ios_base::in | std::ios_base::binary);
+		boost::iostreams::stream<boost::iostreams::file_descriptor_source> is;
 
 		try
 		{


### PR DESCRIPTION
isをその下のtry内で再度openしています。
Linuxのboostだとエラー(file is already open)になります。
