### PR TITLE
DLL用APIで出力バッファを超えて書き込むことがある不具合を修正

### DIFF
--- a/common/waifu2x.cpp
+++ b/common/waifu2x.cpp
@@ -845,7 +845,7 @@ Waifu2x::eWaifu2xError Waifu2x::waifu2x(const double factor, const void* source,
 		const auto width = out_image.size().width;
 		const auto stride = out_image.step1();
 		for (int i = 0; i < out_image.size().height; i++)
-			memcpy((uint8_t *)dest + out_stride * i, out_image.data + stride * i, stride);
+			memcpy((uint8_t *)dest + out_stride * i, out_image.data + stride * i, out_stride);
 	}
 
 	return Waifu2x::eWaifu2xError_OK;


### PR DESCRIPTION
OpenCVのstride(step)は、SIMD用にアライメントされていて`channels * width`より大きいことがあるため、`out_stride < out_image.step1()` の場合に、destの領域をはみ出すことがあると思います。
