### PR TITLE
Revert CUDNN_REQUIRE_VERION_TEXT (fixes issue #111)

### DIFF
--- a/common/waifu2x.h
+++ b/common/waifu2x.h
@@ -11,7 +11,7 @@
 #include <opencv2/core.hpp>
 
 #define CUDNN_DLL_NAME "cudnn64_7.dll"
-#define CUDNN_REQUIRE_VERION_TEXT "v7"
+#define CUDNN_REQUIRE_VERION_TEXT "v6"
 
 
 namespace caffe


### PR DESCRIPTION
The file and product version of the latest cudnn64_7.dll (v7.3.1) both begin with a 6. This applies to both the Windows 10 and 7 versions.